### PR TITLE
fix: fix layout of tech cards

### DIFF
--- a/src/components/skills/TechCard.tsx
+++ b/src/components/skills/TechCard.tsx
@@ -18,12 +18,18 @@ export function TechCard({ category, index }: Props) {
   const color = getAccentColor(index);
 
   return (
-    <Card variant="item">
+    <Card
+      variant="item"
+      style={{
+        display: 'grid',
+        gridRow: 'span 2',
+        gridTemplateRows: 'subgrid',
+      }}
+    >
       <Card.Section
         bg={`light-dark(var(--mantine-color-${color}Light-1), var(--mantine-color-${color}Dark-9))`}
         inheritPadding
-        pt="lg"
-        pb="md"
+        py="lg"
       >
         <Stack gap="xs">
           <Title
@@ -37,7 +43,7 @@ export function TechCard({ category, index }: Props) {
         </Stack>
       </Card.Section>
 
-      <TechGroup stack={category.skills} mt="md" />
+      <TechGroup stack={category.skills} style={{ alignSelf: 'start' }} />
     </Card>
   );
 }

--- a/src/components/skills/TechSection.tsx
+++ b/src/components/skills/TechSection.tsx
@@ -17,8 +17,8 @@ export function TechSection({ content }: Props) {
   return (
     <Section title={content.title} icon={IconCode}>
       <SimpleGrid cols={{ base: 1, sm: 2, lg: 4 }} spacing="lg">
-        {content.categories.map((cat, index) => (
-          <TechCard key={index} category={cat} index={index} />
+        {content.categories.map((category, index) => (
+          <TechCard key={index} category={category} index={index} />
         ))}
       </SimpleGrid>
     </Section>


### PR DESCRIPTION
## 📸 Screenshots 

### Mobile

#### Light mode

##### Home page

| Before | After |
| ------ | ----- |
| <img width="1130" height="5060" alt="image" src="https://github.com/user-attachments/assets/7ce09116-afc9-4f2e-baa3-a9b01c51f527" /> |  |

##### Navbar

| Before | After |
| ------ | ----- |
| <img width="560" height="961" alt="image" src="https://github.com/user-attachments/assets/af81f407-270a-47d0-bf59-7c4a6bc3eb6b" /> |  |

##### About page

| Before | After |
| ------ | ----- |
| <img width="1170" height="10322" alt="image" src="https://github.com/user-attachments/assets/79523552-6941-4267-ba95-9fc3aa11b601" /> |  |

##### Projects page

| Before | After |
| ------ | ----- |
| <img width="1130" height="9034" alt="image" src="https://github.com/user-attachments/assets/48fec861-5ab8-4189-b44c-90dbf98ef71e" /> |  |

##### Project detail page

| Before | After |
| ------ | ----- |
| <img width="1130" height="8340" alt="image" src="https://github.com/user-attachments/assets/9d11e057-2281-4558-a3a8-90e4cfe80218" /> |  |

##### Articles page

| Before | After |
| ------ | ----- |
| <img width="1130" height="16230" alt="image" src="https://github.com/user-attachments/assets/419f849f-0438-4980-b7e2-d67280b70dd7" /> |  |

##### Skills page

| Before | After |
| ------ | ----- |
| <img width="1170" height="10410" alt="image" src="https://github.com/user-attachments/assets/89b77859-109a-4079-8a4f-603cfc76f6a4" /> | <img width="1130" height="10562" alt="image" src="https://github.com/user-attachments/assets/f607532c-9862-44e8-b245-df23398dbae0" /> |

##### Contact page

| Before | After |
| ------ | ----- |
| <img width="1130" height="5400" alt="image" src="https://github.com/user-attachments/assets/e43620c6-f1aa-4c05-bb91-3b128031beee" /> |  |

##### 404 page

| Before | After |
| ------ | ----- |
| <img width="1130" height="5108" alt="image" src="https://github.com/user-attachments/assets/e9e8a84a-4a3a-4245-9b3f-8b0f004f771b" /> |  |


#### Dark mode

##### Home page

| Before | After |
| ------ | ----- |
| <img width="1130" height="5060" alt="image" src="https://github.com/user-attachments/assets/cb4d033a-ad91-4a45-89e9-9340e3766073" /> |  |

##### Navbar

| Before | After |
| ------ | ----- |
| <img width="560" height="961" alt="image" src="https://github.com/user-attachments/assets/3c0db62a-b1c3-45c9-955c-7c96e8ccad17" /> |  |

##### About page

| Before | After |
| ------ | ----- |
| <img width="1170" height="10322" alt="image" src="https://github.com/user-attachments/assets/cb5dfec9-cffb-4af7-a900-0426b6f34889" /> |  |

##### Projects page

| Before | After |
| ------ | ----- |
| <img width="1130" height="9034" alt="image" src="https://github.com/user-attachments/assets/3aaa7665-d0a6-46d9-9eef-9f41bbadfbeb" /> |  |

##### Project detail page

| Before | After |
| ------ | ----- |
| <img width="1130" height="8340" alt="image" src="https://github.com/user-attachments/assets/6b78504d-201a-43e8-89ad-0a23794883a3" /> |  |

##### Articles page

| Before | After |
| ------ | ----- |
| <img width="1130" height="16230" alt="image" src="https://github.com/user-attachments/assets/c11ac57f-2841-4b2c-bf66-35e8fa965f93" /> |  |

##### Skills page

| Before | After |
| ------ | ----- |
| <img width="1170" height="10410" alt="image" src="https://github.com/user-attachments/assets/df66ef99-6751-49d9-8f74-af16dbe9e43b" /> | <img width="1130" height="10562" alt="image" src="https://github.com/user-attachments/assets/aa8a7aaf-462e-4ada-bd01-8f41d4b3215d" /> |

##### Contact page

| Before | After |
| ------ | ----- |
| <img width="1130" height="5400" alt="image" src="https://github.com/user-attachments/assets/1311acea-94a6-4be9-9918-6419fc821fd5" /> |  |

##### 404 page

| Before | After |
| ------ | ----- |
| <img width="1130" height="5108" alt="image" src="https://github.com/user-attachments/assets/8983f68f-9693-4830-8ca5-e1b27b0dfb8b" /> |  |


### Desktop

#### Light mode

##### Home page

| Before | After |
| ------ | ----- |
| <img width="2618" height="4306" alt="image" src="https://github.com/user-attachments/assets/c3e16e61-aa0d-4ce2-9064-850e2e47b8e8" /> |  |

##### About page

| Before | After |
| ------ | ----- |
| <img width="2658" height="6974" alt="image" src="https://github.com/user-attachments/assets/2e2ab86c-2623-4370-b005-24ddf2aeefaf" /> |  |

##### Projects page

| Before | After |
| ------ | ----- |
| <img width="2618" height="5530" alt="image" src="https://github.com/user-attachments/assets/090e5687-ab9a-4040-8de5-84bbd2d6030c" /> |  |

##### Project detail page

| Before | After |
| ------ | ----- |
| <img width="2618" height="6074" alt="image" src="https://github.com/user-attachments/assets/335a12fe-aeb2-4f15-9123-044b963cdfc6" /> |  |

##### Articles page

| Before | After |
| ------ | ----- |
| <img width="2618" height="8620" alt="image" src="https://github.com/user-attachments/assets/c2b61b0d-e328-44e4-b89e-89290deb6461" /> |  |

##### Skills page

| Before | After |
| ------ | ----- |
| <img width="2658" height="6270" alt="image" src="https://github.com/user-attachments/assets/5b9e5dd3-092d-4e99-9f2e-c56bd084decc" /> | <img width="2618" height="6302" alt="image" src="https://github.com/user-attachments/assets/97c57f46-36f2-4fc3-94c0-433bab9d420c" /> |

##### Contact page

| Before | After |
| ------ | ----- |
| <img width="2618" height="3924" alt="image" src="https://github.com/user-attachments/assets/d80ac9f4-819e-4aeb-a51e-90f47c5e45d2" /> |  |

##### 404 page

| Before | After |
| ------ | ----- |
| <img width="2618" height="3546" alt="image" src="https://github.com/user-attachments/assets/d8fc7d12-05b5-451d-8631-a8b9f4c002fd" /> |  |


#### Dark mode

##### Home page

| Before | After |
| ------ | ----- |
| <img width="2618" height="4306" alt="image" src="https://github.com/user-attachments/assets/d47450ab-284c-4e45-bc89-44eaf2094119" /> |  |

##### About page

| Before | After |
| ------ | ----- |
| <img width="2658" height="6974" alt="image" src="https://github.com/user-attachments/assets/0fe94c52-0acd-475c-9b5f-8a19466afe4e" /> |  |

##### Projects page

| Before | After |
| ------ | ----- |
| <img width="2618" height="5530" alt="image" src="https://github.com/user-attachments/assets/3309eabc-b875-42e0-b0cd-d868dc2d750a" /> |  |

##### Project detail page

| Before | After |
| ------ | ----- |
| <img width="2618" height="6074" alt="image" src="https://github.com/user-attachments/assets/5d6e54e4-d5cf-4541-bbda-94a401668d00" /> |  |

##### Articles page

| Before | After |
| ------ | ----- |
| <img width="2618" height="8620" alt="image" src="https://github.com/user-attachments/assets/ca4965cf-7b90-4850-9321-a1b21810b8c4" /> |  |

##### Skills page

| Before | After |
| ------ | ----- |
| <img width="2658" height="6270" alt="image" src="https://github.com/user-attachments/assets/3025f54f-5f5b-496f-885b-9cbfccce007d" /> | <img width="2618" height="6302" alt="image" src="https://github.com/user-attachments/assets/f41fe242-2bbe-403f-99dc-ec8643fe78d1" /> |

##### Contact page

| Before | After |
| ------ | ----- |
| <img width="2618" height="3924" alt="image" src="https://github.com/user-attachments/assets/69bd3638-3e12-4f63-8100-c04c0f8eb57e" /> |  |

##### 404 page

| Before | After |
| ------ | ----- |
| <img width="2618" height="3546" alt="image" src="https://github.com/user-attachments/assets/7e865b44-907d-4bce-9149-5f62f8ac025e" /> |  |

