### PR TITLE
fix(ui): CTA button text is truncated and overlaps with icon on mobile

### DIFF
--- a/src/theme/components/button.ts
+++ b/src/theme/components/button.ts
@@ -2,4 +2,10 @@ import { Button, MantineThemeComponents } from '@mantine/core';
 
 export const ButtonTheme: MantineThemeComponents['Button'] = Button.extend({
   defaultProps: { size: 'sm', color: 'brand', variant: 'filled' },
+
+  styles: {
+    label: {
+      whiteSpace: 'normal',
+    },
+  },
 });


### PR DESCRIPTION
## 📸 Screenshots 

### Mobile

#### Light mode

##### Home page

| Before | After |
| ------ | ----- |
| <img width="896" height="5488" alt="image" src="https://github.com/user-attachments/assets/0980f36f-5296-4a05-804d-d027e2a6f36c" /> | <img width="548" height="7286" alt="image" src="https://github.com/user-attachments/assets/e064a95c-6da5-4997-950b-1a8a0406f095" /> |

##### Navbar

| Before | After |
| ------ | ----- |
| <img width="560" height="961" alt="image" src="https://github.com/user-attachments/assets/af81f407-270a-47d0-bf59-7c4a6bc3eb6b" /> |  |

##### About page

| Before | After |
| ------ | ----- |
| <img width="896" height="10728" alt="image" src="https://github.com/user-attachments/assets/b401e0dc-b5e8-4473-aeed-cd219137372a" /> |  |

##### Projects page

| Before | After |
| ------ | ----- |
| <img width="896" height="8742" alt="image" src="https://github.com/user-attachments/assets/2192eea8-9e92-406d-9da0-e1b2dd7fb5a0" /> |  |

##### Project detail page

| Before | After |
| ------ | ----- |
| <img width="896" height="8850" alt="image" src="https://github.com/user-attachments/assets/8f990af7-48ee-49ef-8d34-e7c79dfac66e" /> |  |

##### Articles page

| Before | After |
| ------ | ----- |
| <img width="896" height="15182" alt="image" src="https://github.com/user-attachments/assets/93efc2f3-75bc-417c-a1ef-e121f8404ac9" /> |  |

##### Skills page

| Before | After |
| ------ | ----- |
| <img width="896" height="11160" alt="image" src="https://github.com/user-attachments/assets/018d8880-00b1-44e4-90a9-c26bdaebe9f7" /> |  |

##### Contact page

| Before | After |
| ------ | ----- |
| <img width="896" height="5498" alt="image" src="https://github.com/user-attachments/assets/18054446-8064-408b-9ee7-0456afee6ea3" /> |  |

##### 404 page

| Before | After |
| ------ | ----- |
| <img width="896" height="5064" alt="image" src="https://github.com/user-attachments/assets/bd904549-402a-4877-80f0-2cc2c30895b5" /> |  |


#### Dark mode

##### Home page

| Before | After |
| ------ | ----- |
| <img width="896" height="5488" alt="image" src="https://github.com/user-attachments/assets/b6f4ef3b-52ed-43b3-9597-c80302faa243" /> | <img width="548" height="7286" alt="image" src="https://github.com/user-attachments/assets/d766cb61-0e82-441c-82b0-ea019fd56efc" /> |

##### Navbar

| Before | After |
| ------ | ----- |
| <img width="560" height="961" alt="image" src="https://github.com/user-attachments/assets/3c0db62a-b1c3-45c9-955c-7c96e8ccad17" /> |  |

##### About page

| Before | After |
| ------ | ----- |
| <img width="896" height="10728" alt="image" src="https://github.com/user-attachments/assets/70948e33-9f8f-4193-a641-79a4140806e0" /> |  |

##### Projects page

| Before | After |
| ------ | ----- |
| <img width="896" height="8742" alt="image" src="https://github.com/user-attachments/assets/58c43f70-fb08-4812-b50f-6d31fd70cad8" /> |  |

##### Project detail page

| Before | After |
| ------ | ----- |
| <img width="896" height="8850" alt="image" src="https://github.com/user-attachments/assets/f460b289-aef6-462c-a031-44996ac45ebe" /> |  |

##### Articles page

| Before | After |
| ------ | ----- |
| <img width="896" height="15182" alt="image" src="https://github.com/user-attachments/assets/7acef52b-98b1-4483-b824-d2ecc2bd10d4" /> |  |

##### Skills page

| Before | After |
| ------ | ----- |
| <img width="896" height="11160" alt="image" src="https://github.com/user-attachments/assets/13675a64-00d3-40b6-84a6-3a1f30de62bf" /> |  |

##### Contact page

| Before | After |
| ------ | ----- |
| <img width="896" height="5498" alt="image" src="https://github.com/user-attachments/assets/c2307890-177a-4165-9aea-494d4e9e7270" /> |  |

##### 404 page

| Before | After |
| ------ | ----- |
| <img width="896" height="5064" alt="image" src="https://github.com/user-attachments/assets/d8d4fe8a-4e89-4347-9b24-5b42036c2f65" /> |  |


### Desktop

#### Light mode

##### Home page

| Before | After |
| ------ | ----- |
| <img width="2600" height="4242" alt="image" src="https://github.com/user-attachments/assets/9f153249-7015-4a7b-a20f-9845298b1749" /> | <img width="2600" height="4242" alt="image" src="https://github.com/user-attachments/assets/ec202bae-bc29-47fa-a0b7-8da94a7c8448" /> |

##### About page

| Before | After |
| ------ | ----- |
| <img width="2600" height="6846" alt="image" src="https://github.com/user-attachments/assets/d51efde6-6768-45e1-b624-2e85a0d0025c" /> |  |

##### Projects page

| Before | After |
| ------ | ----- |
| <img width="2600" height="5490" alt="image" src="https://github.com/user-attachments/assets/620b9aa7-9f56-49aa-9a7b-97a26a41e228" />  |  |

##### Project detail page

| Before | After |
| ------ | ----- |
| <img width="2600" height="6074" alt="image" src="https://github.com/user-attachments/assets/7389776f-ef26-4619-bfe3-67643cffe6a6" /> |  |

##### Articles page

| Before | After |
| ------ | ----- |
| <img width="2600" height="8620" alt="image" src="https://github.com/user-attachments/assets/b46f46b6-82f8-4792-9461-fdf31b9176d5" /> |  |

##### Skills page

| Before | After |
| ------ | ----- |
| <img width="2600" height="6270" alt="image" src="https://github.com/user-attachments/assets/40b472c2-1372-4640-9b6f-274c15a1ffc5" /> |  |

##### Contact page

| Before | After |
| ------ | ----- |
| <img width="2600" height="3782" alt="image" src="https://github.com/user-attachments/assets/c8831e94-7e22-43a9-802f-e19d70c67a14" /> |  |

##### 404 page

| Before | After |
| ------ | ----- |
| <img width="2600" height="3538" alt="image" src="https://github.com/user-attachments/assets/368e5fc5-9bd3-4231-97a4-ee3d9839102b" /> |  |


#### Dark mode

##### Home page

| Before | After |
| ------ | ----- |
| <img width="2600" height="4242" alt="image" src="https://github.com/user-attachments/assets/772e884c-bc32-468f-8c59-e6402c3196bf" /> | <img width="2600" height="4242" alt="image" src="https://github.com/user-attachments/assets/7f21f3be-5d09-401d-87cf-ade82e85729d" /> |

##### About page

| Before | After |
| ------ | ----- |
| <img width="2600" height="6846" alt="image" src="https://github.com/user-attachments/assets/d2654b01-3757-46a4-ab7d-492d6c61a139" /> |  |

##### Projects page

| Before | After |
| ------ | ----- |
| <img width="2600" height="5490" alt="image" src="https://github.com/user-attachments/assets/64096219-0ba7-40e3-b716-cdb3aa7b5b18" /> |  |

##### Project detail page

| Before | After |
| ------ | ----- |
| <img width="2600" height="6074" alt="image" src="https://github.com/user-attachments/assets/300791fa-6d8e-4e75-bf54-12ef039541d2" /> |  |

##### Articles page

| Before | After |
| ------ | ----- |
| <img width="2600" height="8620" alt="image" src="https://github.com/user-attachments/assets/1ae16ce3-0076-4aa3-8744-d8a5b7c6ba6e" /> |  |

##### Skills page

| Before | After |
| ------ | ----- |
| <img width="2600" height="6270" alt="image" src="https://github.com/user-attachments/assets/7a76965a-3bd6-4c99-9d5b-34f9227eb6a1" /> |  |

##### Contact page

| Before | After |
| ------ | ----- |
| <img width="2600" height="3782" alt="image" src="https://github.com/user-attachments/assets/b859e674-f42e-4706-b851-32344186fde3" /> |  |

##### 404 page

| Before | After |
| ------ | ----- |
| <img width="2600" height="3538" alt="image" src="https://github.com/user-attachments/assets/64bef9cd-7ad6-498d-b443-3cd01726fde2" /> |  |


---

## 🔗 Related issue

Closes #191